### PR TITLE
Some API changes and diagnostics for OrzIR frontend

### DIFF
--- a/src/collections.rs
+++ b/src/collections.rs
@@ -1,4 +1,5 @@
 pub mod bimap;
+pub mod diagnostic;
 pub mod list;
 
 pub use bimap::*;

--- a/src/collections/diagnostic.rs
+++ b/src/collections/diagnostic.rs
@@ -1,0 +1,100 @@
+use std::{
+    fmt,
+    io::{self, BufRead},
+};
+
+pub enum Level {
+    Info,
+    Warn,
+    Error,
+}
+
+pub struct Diagnostic<'a> {
+    source: &'a str,
+    level: Level,
+    filename: String,
+    message: String,
+
+    source_rows: (usize, usize),
+    diagnostic_row: usize,
+    diagnostic_cols: (usize, usize),
+}
+
+impl Diagnostic<'_> {
+    pub fn new(
+        source: &str,
+        level: Level,
+        filename: String,
+        message: String,
+        source_rows: (usize, usize),
+        diagnostic_row: usize,
+        diagnostic_cols: (usize, usize),
+    ) -> Diagnostic<'_> {
+        Diagnostic {
+            source,
+            level,
+            filename,
+            message,
+            source_rows,
+            diagnostic_row,
+            diagnostic_cols,
+        }
+    }
+}
+
+impl<'a> fmt::Display for Diagnostic<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let level = match self.level {
+            Level::Info => "info",
+            Level::Warn => "warn",
+            Level::Error => "error",
+        };
+
+        writeln!(f, "{}", level)?;
+
+        let lineno_width = self.source_rows.1.to_string().len() - 1;
+
+        let indent = " ".repeat(lineno_width);
+        writeln!(
+            f,
+            "{} ---> {}:{}:{}",
+            indent, self.filename, self.diagnostic_row, self.diagnostic_cols.0
+        )?;
+
+        // for each line within the span, the format is:
+        // LL | <src>
+        // if the line is within the diagnostic span, the format is:
+        // LL | <src>
+        //    | ^^^^^ <message>
+        // seek to the start of the span
+        let reader = io::BufReader::new(self.source.as_bytes());
+        let lines = reader
+            .lines()
+            .skip(self.source_rows.0 - 1)
+            .take(self.source_rows.1 - self.source_rows.0 + 1);
+
+        let indent = " ".repeat(lineno_width + 1);
+        writeln!(f, "{} |", indent)?;
+        for line in lines {
+            let line = line.unwrap();
+            let lineno = self.source_rows.0;
+            let lineno_str = lineno.to_string();
+            let lineno_str = format!("{:width$}", lineno_str, width = lineno_width);
+
+            writeln!(f, "{} | {}", lineno_str, line)?;
+
+            if lineno == self.diagnostic_row {
+                let col_width = self.diagnostic_cols.1 - self.diagnostic_cols.0;
+                let carets = "^".repeat(col_width + 1);
+                let space_before_carets = " ".repeat(self.diagnostic_cols.0 - 1);
+                writeln!(
+                    f,
+                    "{} | {}{} {}",
+                    indent, space_before_carets, carets, self.message
+                )?;
+            }
+        }
+        writeln!(f, "{} |", indent)?;
+        Ok(())
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -147,13 +147,13 @@
 pub mod builders;
 pub mod entities;
 pub mod exec;
+pub mod format;
 pub mod frontend;
 pub mod layout;
 pub mod module;
 pub mod passes;
 pub mod types;
 pub mod values;
-pub mod format;
 
 #[allow(dead_code)]
 const LOCAL_PREFIX: &str = "%";

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -101,15 +101,15 @@
 //! // Then build global values with the global builder:
 //!
 //! // use the `init` to build a `mutable=true` global slot/
-//! let init = module.builder().zero(Type::mk_i32()).unwrap();
+//! let init = module.builder().zero(Type::i32_()).unwrap();
 //! let var = module.builder().global_slot(init, true).unwrap();
 //!
 //! // use the `init` to build a `mutable=false` global slot, which is a constant.
-//! let init = module.builder().zero(Type::mk_i32()).unwrap();
+//! let init = module.builder().zero(Type::i32_()).unwrap();
 //! let const_ = module.builder().global_slot(init, false).unwrap();
 //!
 //! // construct a function type.
-//! let ty = Type::mk_function(vec![Type::mk_i32()], Type::mk_i32());
+//! let ty = Type::function(vec![Type::i32_()], Type::i32_());
 //! // there are also `function_decl` and `function_intrinsic` methods.
 //! let function = module.builder().function_def(ty).unwrap();
 //!
@@ -119,11 +119,11 @@
 //!
 //! // example: build an entry block, and since there is a parameter of the function, we need to
 //! // add the parameter to the block.
-//! let param = function_data.dfg_mut().builder().block_param(Type::mk_i32()).unwrap();
+//! let param = function_data.dfg_mut().builder().block_param(Type::i32_()).unwrap();
 //! let entry = function_data.dfg_mut().builder().block(vec![param]).unwrap();
 //!
 //! // example: allocate a stack slot.
-//! let inst = function_data.dfg_mut().builder().alloc(Type::mk_i32()).unwrap();
+//! let inst = function_data.dfg_mut().builder().alloc(Type::i32_()).unwrap();
 //!
 //! // next, we need to add the inst to the block in the function layout.
 //! function_data.layout_mut().append_block(entry).unwrap();

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -153,6 +153,7 @@ pub mod module;
 pub mod passes;
 pub mod types;
 pub mod values;
+pub mod format;
 
 #[allow(dead_code)]
 const LOCAL_PREFIX: &str = "%";

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -87,7 +87,8 @@
 //! ```rust
 //! use orzcc::ir::{
 //!     builders::{
-//!         BuilderErr, ConstantBuilder, GlobalValueBuilder, LocalBlockBuilder, LocalValueBuilder,
+//!         BuildError, BuildGlobalValue, BuildBlock, BuildLocalValue,
+//!         BuildNonAggregateConstant,
 //!     },
 //!     module::Module,
 //!     types::Type,

--- a/src/ir/builders.rs
+++ b/src/ir/builders.rs
@@ -24,7 +24,7 @@ use super::{
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum BuilderErr {
+pub enum BuildError {
     /// Value not found.
     ///
     /// The value is not found in the data flow graph.
@@ -100,13 +100,13 @@ pub enum BuilderErr {
 /// This trait is used to provide the query interface for builder.
 pub trait QueryValueData {
     /// Get the type of a value.
-    fn value_type(&self, value: Value) -> Result<Type, BuilderErr>;
+    fn value_type(&self, value: Value) -> Result<Type, BuildError>;
 
     /// Check if a value is a constant.
-    fn is_value_const(&self, value: Value) -> Result<bool, BuilderErr>;
+    fn is_value_const(&self, value: Value) -> Result<bool, BuildError>;
 
     /// Check if a value is a block parameter.
-    fn is_value_block_param(&self, value: Value) -> Result<bool, BuilderErr>;
+    fn is_value_block_param(&self, value: Value) -> Result<bool, BuildError>;
 
     /// Check if a value exists in the data flow graph.
     fn value_exists(&self, value: Value) -> bool {
@@ -115,46 +115,45 @@ pub trait QueryValueData {
 }
 
 pub trait QueryBlockData {
-    fn block_data(&self, block: Block) -> Result<&BlockData, BuilderErr>;
+    fn block_data(&self, block: Block) -> Result<&BlockData, BuildError>;
 }
 
 pub trait QueryDfgData: QueryValueData + QueryBlockData {}
 
 /// Add value to the data flow graph or the module.
 pub trait AddValue {
-    fn add_value(&mut self, data: ValueData) -> Result<Value, BuilderErr>;
+    fn add_value(&mut self, data: ValueData) -> Result<Value, BuildError>;
 }
 
 /// Add block to the data flow graph.
 pub trait AddBlock {
-    fn add_block(&mut self, data: BlockData) -> Result<Block, BuilderErr>;
+    fn add_block(&mut self, data: BlockData) -> Result<Block, BuildError>;
 }
 
-/// Constant builder for both global and local purposes.
-pub trait ConstantBuilder: QueryValueData + AddValue {
+pub trait BuildNonAggregateConstant: QueryValueData + AddValue {
     /// Build a zero constant.
-    fn zero(&mut self, ty: Type) -> Result<Value, BuilderErr> {
+    fn zero(&mut self, ty: Type) -> Result<Value, BuildError> {
         if !ty.is_zero_initializable() {
-            return Err(BuilderErr::InvalidType(ty));
+            return Err(BuildError::InvalidType(ty));
         }
         self.add_value(ValueData::new(ty, ValueKind::Zero))
     }
 
     /// Build an undef constant.
-    fn undef(&mut self, ty: Type) -> Result<Value, BuilderErr> {
+    fn undef(&mut self, ty: Type) -> Result<Value, BuildError> {
         self.add_value(ValueData::new(ty, ValueKind::Undef))
     }
 
     /// Build a bytes constant.
-    fn bytes(&mut self, ty: Type, bytes: Vec<u8>) -> Result<Value, BuilderErr> {
+    fn bytes(&mut self, ty: Type, bytes: Vec<u8>) -> Result<Value, BuildError> {
         if !ty.is_numeric() && !ty.is_ptr() {
-            return Err(BuilderErr::InvalidType(ty));
+            return Err(BuildError::InvalidType(ty));
         }
         self.add_value(ValueData::new(ty, ValueKind::Bytes(bytes)))
     }
 
     /// Build an integer constant of i32 type.
-    fn integer(&mut self, value: i32) -> Result<Value, BuilderErr> {
+    fn integer(&mut self, value: i32) -> Result<Value, BuildError> {
         let bytes = value.to_le_bytes().to_vec();
 
         // remove leading zeros
@@ -173,30 +172,33 @@ pub trait ConstantBuilder: QueryValueData + AddValue {
     /// Build a float constant.
     ///
     /// This is a shorthand for `bytes` with the bytes of the float.
-    fn float(&mut self, value: f32) -> Result<Value, BuilderErr> {
+    fn float(&mut self, value: f32) -> Result<Value, BuildError> {
         let bytes = value.to_le_bytes().to_vec();
         self.bytes(Type::mk_float(), bytes)
     }
+}
 
+/// Constant builder for both global and local purposes.
+pub trait BuildAggregateConstant: QueryValueData + AddValue {
     /// Build an array constant.
-    fn array(&mut self, ty: Type, values: Vec<Value>) -> Result<Value, BuilderErr> {
+    fn array(&mut self, ty: Type, values: Vec<Value>) -> Result<Value, BuildError> {
         let (size, elem_type) = ty
             .as_array()
-            .ok_or_else(|| BuilderErr::InvalidType(ty.clone()))?;
+            .ok_or_else(|| BuildError::InvalidType(ty.clone()))?;
 
         if values.len() != size {
-            return Err(BuilderErr::IncompatibleArraySize(size, values.len()));
+            return Err(BuildError::IncompatibleArraySize(size, values.len()));
         }
 
         for value in &values {
             if self.value_type(*value)? != elem_type.clone() {
-                return Err(BuilderErr::IncompatibleArrayElemType(
+                return Err(BuildError::IncompatibleArrayElemType(
                     elem_type,
                     self.value_type(*value)?,
                 ));
             }
             if !self.is_value_const(*value)? {
-                return Err(BuilderErr::InvalidMutability);
+                return Err(BuildError::InvalidMutability);
             }
         }
 
@@ -204,13 +206,13 @@ pub trait ConstantBuilder: QueryValueData + AddValue {
     }
 
     /// Build a struct constant.
-    fn struct_(&mut self, ty: Type, values: Vec<Value>) -> Result<Value, BuilderErr> {
+    fn struct_(&mut self, ty: Type, values: Vec<Value>) -> Result<Value, BuildError> {
         let fields = ty
             .as_struct()
-            .ok_or_else(|| BuilderErr::InvalidType(ty.clone()))?;
+            .ok_or_else(|| BuildError::InvalidType(ty.clone()))?;
 
         if fields.len() != values.len() {
-            return Err(BuilderErr::IncompatibleStructFieldNumber(
+            return Err(BuildError::IncompatibleStructFieldNumber(
                 fields.len(),
                 values.len(),
             ));
@@ -218,13 +220,13 @@ pub trait ConstantBuilder: QueryValueData + AddValue {
 
         for (field_type, value) in fields.iter().zip(&values) {
             if self.value_type(*value)? != field_type.clone() {
-                return Err(BuilderErr::IncompatibleStructFieldType(
+                return Err(BuildError::IncompatibleStructFieldType(
                     field_type.clone(),
                     self.value_type(*value)?,
                 ));
             }
             if !self.is_value_const(*value)? {
-                return Err(BuilderErr::InvalidMutability);
+                return Err(BuildError::InvalidMutability);
             }
         }
 
@@ -233,58 +235,58 @@ pub trait ConstantBuilder: QueryValueData + AddValue {
 }
 
 /// Local value builder for local data flow graph.
-pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
+pub trait BuildLocalValue: QueryDfgData + AddValue + BuildNonAggregateConstant {
     /// Build a block parameter.
-    fn block_param(&mut self, ty: Type) -> Result<Value, BuilderErr> {
+    fn block_param(&mut self, ty: Type) -> Result<Value, BuildError> {
         self.add_value(ValueData::new(ty, ValueKind::BlockParam))
     }
 
     /// Build an alloc instruction.
-    fn alloc(&mut self, ty: Type) -> Result<Value, BuilderErr> {
+    fn alloc(&mut self, ty: Type) -> Result<Value, BuildError> {
         self.add_value(Alloc::new_value_data(ty))
     }
 
     /// Build a load instruction.
-    fn load(&mut self, ty: Type, ptr: Value) -> Result<Value, BuilderErr> {
+    fn load(&mut self, ty: Type, ptr: Value) -> Result<Value, BuildError> {
         if !self.value_type(ptr)?.is_ptr() {
-            return Err(BuilderErr::InvalidType(ty));
+            return Err(BuildError::InvalidType(ty));
         }
         self.add_value(Load::new_value_data(ty, ptr))
     }
 
     /// Build a cast instruction
-    fn cast(&mut self, op: CastOp, ty: Type, val: Value) -> Result<Value, BuilderErr> {
+    fn cast(&mut self, op: CastOp, ty: Type, val: Value) -> Result<Value, BuildError> {
         self.add_value(Cast::new_value_data(op, ty, val))
     }
 
     /// Build a store instruction.
-    fn store(&mut self, val: Value, ptr: Value) -> Result<Value, BuilderErr> {
+    fn store(&mut self, val: Value, ptr: Value) -> Result<Value, BuildError> {
         if !self.value_type(ptr)?.is_ptr() {
-            return Err(BuilderErr::InvalidType(self.value_type(ptr)?));
+            return Err(BuildError::InvalidType(self.value_type(ptr)?));
         }
 
         if !self.value_exists(val) {
-            return Err(BuilderErr::ValueNotFound);
+            return Err(BuildError::ValueNotFound);
         }
 
         self.add_value(Store::new_value_data(val, ptr))
     }
 
     /// Build a binary instruction.
-    fn binary(&mut self, op: BinaryOp, lhs: Value, rhs: Value) -> Result<Value, BuilderErr> {
+    fn binary(&mut self, op: BinaryOp, lhs: Value, rhs: Value) -> Result<Value, BuildError> {
         let lhs_type = self.value_type(lhs)?;
         let rhs_type = self.value_type(rhs)?;
 
         if op.require_int() && (!lhs_type.is_int() || !rhs_type.is_int()) {
-            return Err(BuilderErr::InvalidType(lhs_type));
+            return Err(BuildError::InvalidType(lhs_type));
         }
 
         if op.require_float() && (!lhs_type.is_float() || !rhs_type.is_float()) {
-            return Err(BuilderErr::InvalidType(lhs_type));
+            return Err(BuildError::InvalidType(lhs_type));
         }
 
         if op.require_same_type() && lhs_type != rhs_type {
-            return Err(BuilderErr::IncompatibleType(lhs_type, rhs_type));
+            return Err(BuildError::IncompatibleType(lhs_type, rhs_type));
         }
 
         let res_type = match op {
@@ -296,26 +298,26 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
     }
 
     /// Build a unary instruction.
-    fn unary(&mut self, op: UnaryOp, val: Value) -> Result<Value, BuilderErr> {
+    fn unary(&mut self, op: UnaryOp, val: Value) -> Result<Value, BuildError> {
         let val_type = self.value_type(val)?;
 
         if op.require_int() && !val_type.is_int() {
-            return Err(BuilderErr::InvalidType(val_type));
+            return Err(BuildError::InvalidType(val_type));
         }
 
         if op.require_float() && !val_type.is_float() {
-            return Err(BuilderErr::InvalidType(val_type));
+            return Err(BuildError::InvalidType(val_type));
         }
 
         self.add_value(Unary::new_value_data(val_type, op, val))
     }
 
     /// Build a jump instruction.
-    fn jump(&mut self, dst: Block, args: Vec<Value>) -> Result<Value, BuilderErr> {
+    fn jump(&mut self, dst: Block, args: Vec<Value>) -> Result<Value, BuildError> {
         let block_data = self.block_data(dst)?;
 
         if block_data.params().len() != args.len() {
-            return Err(BuilderErr::IncompatibleBlockArgNumber(
+            return Err(BuildError::IncompatibleBlockArgNumber(
                 block_data.params().len(),
                 args.len(),
             ));
@@ -326,7 +328,7 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
             let arg_type = self.value_type(*arg)?;
 
             if param_type != arg_type {
-                return Err(BuilderErr::IncompatibleBlockArgType(param_type, arg_type));
+                return Err(BuildError::IncompatibleBlockArgType(param_type, arg_type));
             }
         }
 
@@ -341,23 +343,23 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
         else_dst: Block,
         then_args: Vec<Value>,
         else_args: Vec<Value>,
-    ) -> Result<Value, BuilderErr> {
+    ) -> Result<Value, BuildError> {
         if !self.value_type(cond)?.is_int() {
-            return Err(BuilderErr::InvalidType(self.value_type(cond)?));
+            return Err(BuildError::InvalidType(self.value_type(cond)?));
         }
 
         let then_block_data = self.block_data(then_dst)?;
         let else_block_data = self.block_data(else_dst)?;
 
         if then_block_data.params().len() != then_args.len() {
-            return Err(BuilderErr::IncompatibleBlockArgNumber(
+            return Err(BuildError::IncompatibleBlockArgNumber(
                 then_block_data.params().len(),
                 then_args.len(),
             ));
         }
 
         if else_block_data.params().len() != else_args.len() {
-            return Err(BuilderErr::IncompatibleBlockArgNumber(
+            return Err(BuildError::IncompatibleBlockArgNumber(
                 else_block_data.params().len(),
                 else_args.len(),
             ));
@@ -368,7 +370,7 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
             let arg_type = self.value_type(*arg)?;
 
             if param_type != arg_type {
-                return Err(BuilderErr::IncompatibleBlockArgType(param_type, arg_type));
+                return Err(BuildError::IncompatibleBlockArgType(param_type, arg_type));
             }
         }
 
@@ -377,7 +379,7 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
             let arg_type = self.value_type(*arg)?;
 
             if param_type != arg_type {
-                return Err(BuilderErr::IncompatibleBlockArgType(param_type, arg_type));
+                return Err(BuildError::IncompatibleBlockArgType(param_type, arg_type));
             }
         }
 
@@ -387,17 +389,17 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
     }
 
     /// Build a return instruction.
-    fn return_(&mut self, val: Option<Value>) -> Result<Value, BuilderErr> {
+    fn return_(&mut self, val: Option<Value>) -> Result<Value, BuildError> {
         // type check of return is not performed here
         self.add_value(Return::new_value_data(val))
     }
 
     /// Build a call instruction.
-    fn call(&mut self, ret_ty: Type, callee: Value, args: Vec<Value>) -> Result<Value, BuilderErr> {
+    fn call(&mut self, ret_ty: Type, callee: Value, args: Vec<Value>) -> Result<Value, BuildError> {
         let callee_type = self.value_type(callee)?;
 
         if !callee_type.is_function() && !callee_type.is_ptr() {
-            return Err(BuilderErr::InvalidType(callee_type));
+            return Err(BuildError::InvalidType(callee_type));
         }
 
         self.add_value(Call::new_value_data(ret_ty, callee, args))
@@ -409,9 +411,9 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
         ptr: Value,
         ty: Type,
         indices: Vec<Value>,
-    ) -> Result<Value, BuilderErr> {
+    ) -> Result<Value, BuildError> {
         if !self.value_type(ptr)?.is_ptr() {
-            return Err(BuilderErr::InvalidType(self.value_type(ptr)?));
+            return Err(BuildError::InvalidType(self.value_type(ptr)?));
         }
 
         self.add_value(GetElemPtr::new_value_data(ptr, ty, indices))
@@ -419,12 +421,12 @@ pub trait LocalValueBuilder: QueryDfgData + AddValue + ConstantBuilder {
 }
 
 /// Block builder for local data flow graph.
-pub trait LocalBlockBuilder: QueryDfgData + AddBlock {
+pub trait BuildBlock: QueryDfgData + AddBlock {
     /// Build a block.
-    fn block(&mut self, params: Vec<Value>) -> Result<Block, BuilderErr> {
+    fn block(&mut self, params: Vec<Value>) -> Result<Block, BuildError> {
         for param in params.iter() {
             if !self.is_value_block_param(*param)? {
-                return Err(BuilderErr::InvalidKind);
+                return Err(BuildError::InvalidKind);
             }
         }
 
@@ -433,45 +435,47 @@ pub trait LocalBlockBuilder: QueryDfgData + AddBlock {
 }
 
 /// Global value builder for the module.
-pub trait GlobalValueBuilder: QueryValueData + AddValue + ConstantBuilder {
+pub trait BuildGlobalValue:
+    QueryValueData + AddValue + BuildNonAggregateConstant + BuildAggregateConstant
+{
     /// Add a constructed function to the module.
     fn add_function(
         &mut self,
         value_data: ValueData,
         function_data: FunctionData,
-    ) -> Result<Function, BuilderErr>;
+    ) -> Result<Function, BuildError>;
 
     /// Build a global slot.
-    fn global_slot(&mut self, init: Value, mutable: bool) -> Result<Value, BuilderErr> {
+    fn global_slot(&mut self, init: Value, mutable: bool) -> Result<Value, BuildError> {
         if !self.is_value_const(init)? {
-            return Err(BuilderErr::InvalidMutability);
+            return Err(BuildError::InvalidMutability);
         }
 
         self.add_value(GlobalSlot::new_value_data(Type::mk_ptr(), init, mutable))
     }
 
     /// Build a global function.
-    fn function(&mut self, ty: Type, kind: FunctionKind) -> Result<Function, BuilderErr> {
+    fn function(&mut self, ty: Type, kind: FunctionKind) -> Result<Function, BuildError> {
         let data = FunctionData::new(ty, kind);
         self.add_function(data.new_value_data(), data)
     }
 
     /// Build a function definition.
-    fn function_def(&mut self, ty: Type) -> Result<Function, BuilderErr> {
+    fn function_def(&mut self, ty: Type) -> Result<Function, BuildError> {
         let data = FunctionData::new(ty, FunctionKind::Definition);
         let function = self.add_function(data.new_value_data(), data)?;
         Ok(function)
     }
 
     /// Build a function declaration.
-    fn function_decl(&mut self, ty: Type) -> Result<Function, BuilderErr> {
+    fn function_decl(&mut self, ty: Type) -> Result<Function, BuildError> {
         let data = FunctionData::new(ty, FunctionKind::Declaration);
         let function = self.add_function(data.new_value_data(), data)?;
         Ok(function)
     }
 
     /// Build a intrinsic function.
-    fn function_intrinsic(&mut self, ty: Type) -> Result<Function, BuilderErr> {
+    fn function_intrinsic(&mut self, ty: Type) -> Result<Function, BuildError> {
         let data = FunctionData::new(ty, FunctionKind::Intrinsic);
         let function = self.add_function(data.new_value_data(), data)?;
         Ok(function)
@@ -489,51 +493,51 @@ impl LocalBuilder<'_> {
 }
 
 impl QueryValueData for LocalBuilder<'_> {
-    fn value_type(&self, value: Value) -> Result<Type, BuilderErr> {
+    fn value_type(&self, value: Value) -> Result<Type, BuildError> {
         self.dfg
             .with_value_data(value, |data| data.ty())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
-    fn is_value_const(&self, value: Value) -> Result<bool, BuilderErr> {
+    fn is_value_const(&self, value: Value) -> Result<bool, BuildError> {
         self.dfg
             .with_value_data(value, |data| data.kind().is_const())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
-    fn is_value_block_param(&self, value: Value) -> Result<bool, BuilderErr> {
+    fn is_value_block_param(&self, value: Value) -> Result<bool, BuildError> {
         self.dfg
             .with_value_data(value, |data| data.kind().is_block_param())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
 }
 
 impl QueryBlockData for LocalBuilder<'_> {
-    fn block_data(&self, block: Block) -> Result<&BlockData, BuilderErr> {
-        self.dfg.block_data(block).ok_or(BuilderErr::BlockNotFound)
+    fn block_data(&self, block: Block) -> Result<&BlockData, BuildError> {
+        self.dfg.block_data(block).ok_or(BuildError::BlockNotFound)
     }
 }
 
 impl AddValue for LocalBuilder<'_> {
-    fn add_value(&mut self, data: ValueData) -> Result<Value, BuilderErr> {
+    fn add_value(&mut self, data: ValueData) -> Result<Value, BuildError> {
         if data.kind().is_global() {
-            return Err(BuilderErr::InvalidGlobalValue);
+            return Err(BuildError::InvalidGlobalValue);
         }
         Ok(self.dfg.add_value(data))
     }
 }
 
 impl AddBlock for LocalBuilder<'_> {
-    fn add_block(&mut self, data: BlockData) -> Result<Block, BuilderErr> {
+    fn add_block(&mut self, data: BlockData) -> Result<Block, BuildError> {
         Ok(self.dfg.add_block(data))
     }
 }
 
 impl QueryDfgData for LocalBuilder<'_> {}
 
-impl ConstantBuilder for LocalBuilder<'_> {}
+impl BuildNonAggregateConstant for LocalBuilder<'_> {}
 
-impl LocalValueBuilder for LocalBuilder<'_> {}
+impl BuildLocalValue for LocalBuilder<'_> {}
 
-impl LocalBlockBuilder for LocalBuilder<'_> {}
+impl BuildBlock for LocalBuilder<'_> {}
 
 pub struct GlobalBuilder<'a> {
     module: &'a mut Module,
@@ -546,39 +550,41 @@ impl GlobalBuilder<'_> {
 }
 
 impl QueryValueData for GlobalBuilder<'_> {
-    fn value_type(&self, value: Value) -> Result<Type, BuilderErr> {
+    fn value_type(&self, value: Value) -> Result<Type, BuildError> {
         self.module
             .with_value_data(value, |data| data.ty())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
 
-    fn is_value_const(&self, value: Value) -> Result<bool, BuilderErr> {
+    fn is_value_const(&self, value: Value) -> Result<bool, BuildError> {
         self.module
             .with_value_data(value, |data| data.kind().is_const())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
 
-    fn is_value_block_param(&self, value: Value) -> Result<bool, BuilderErr> {
+    fn is_value_block_param(&self, value: Value) -> Result<bool, BuildError> {
         self.module
             .with_value_data(value, |data| data.kind().is_block_param())
-            .ok_or(BuilderErr::ValueNotFound)
+            .ok_or(BuildError::ValueNotFound)
     }
 }
 
 impl AddValue for GlobalBuilder<'_> {
-    fn add_value(&mut self, data: ValueData) -> Result<Value, BuilderErr> {
+    fn add_value(&mut self, data: ValueData) -> Result<Value, BuildError> {
         Ok(self.module.add_global_slot(data))
     }
 }
 
-impl ConstantBuilder for GlobalBuilder<'_> {}
+impl BuildNonAggregateConstant for GlobalBuilder<'_> {}
 
-impl GlobalValueBuilder for GlobalBuilder<'_> {
+impl BuildAggregateConstant for GlobalBuilder<'_> {}
+
+impl BuildGlobalValue for GlobalBuilder<'_> {
     fn add_function(
         &mut self,
         value_data: ValueData,
         function_data: FunctionData,
-    ) -> Result<Function, BuilderErr> {
+    ) -> Result<Function, BuildError> {
         Ok(self.module.add_function(value_data, function_data))
     }
 }

--- a/src/ir/builders.rs
+++ b/src/ir/builders.rs
@@ -166,7 +166,7 @@ pub trait BuildNonAggregateConstant: QueryValueData + AddValue {
             .rev()
             .collect::<Vec<u8>>();
 
-        self.bytes(Type::mk_int(32), bytes)
+        self.bytes(Type::int(32), bytes)
     }
 
     /// Build a float constant.
@@ -174,7 +174,7 @@ pub trait BuildNonAggregateConstant: QueryValueData + AddValue {
     /// This is a shorthand for `bytes` with the bytes of the float.
     fn float(&mut self, value: f32) -> Result<Value, BuildError> {
         let bytes = value.to_le_bytes().to_vec();
-        self.bytes(Type::mk_float(), bytes)
+        self.bytes(Type::float(), bytes)
     }
 }
 
@@ -290,7 +290,7 @@ pub trait BuildLocalValue: QueryDfgData + AddValue + BuildNonAggregateConstant {
         }
 
         let res_type = match op {
-            BinaryOp::ICmp(_) | BinaryOp::FCmp(_) => Type::mk_int(1),
+            BinaryOp::ICmp(_) | BinaryOp::FCmp(_) => Type::int(1),
             _ => lhs_type,
         };
 
@@ -451,7 +451,7 @@ pub trait BuildGlobalValue:
             return Err(BuildError::InvalidMutability);
         }
 
-        self.add_value(GlobalSlot::new_value_data(Type::mk_ptr(), init, mutable))
+        self.add_value(GlobalSlot::new_value_data(Type::ptr(), init, mutable))
     }
 
     /// Build a global function.

--- a/src/ir/builders.rs
+++ b/src/ir/builders.rs
@@ -491,7 +491,7 @@ impl LocalBuilder<'_> {
 impl QueryValueData for LocalBuilder<'_> {
     fn value_type(&self, value: Value) -> Result<Type, BuilderErr> {
         self.dfg
-            .with_value_data(value, |data| data.ty().clone())
+            .with_value_data(value, |data| data.ty())
             .ok_or(BuilderErr::ValueNotFound)
     }
     fn is_value_const(&self, value: Value) -> Result<bool, BuilderErr> {
@@ -548,7 +548,7 @@ impl GlobalBuilder<'_> {
 impl QueryValueData for GlobalBuilder<'_> {
     fn value_type(&self, value: Value) -> Result<Type, BuilderErr> {
         self.module
-            .with_value_data(value, |data| data.ty().clone())
+            .with_value_data(value, |data| data.ty())
             .ok_or(BuilderErr::ValueNotFound)
     }
 

--- a/src/ir/entities.rs
+++ b/src/ir/entities.rs
@@ -223,8 +223,8 @@ impl ValueData {
         Self { ty, kind }
     }
 
-    pub fn ty(&self) -> &Type {
-        &self.ty
+    pub fn ty(&self) -> Type {
+        self.ty.clone()
     }
 
     pub fn kind(&self) -> &ValueKind {

--- a/src/ir/entities.rs
+++ b/src/ir/entities.rs
@@ -67,7 +67,7 @@ impl FunctionData {
     /// The type is a pointer type, and the kind is `Function`. The function type can be found
     /// in the `ty` field of the [`FunctionData`] struct.
     pub fn new_value_data(&self) -> ValueData {
-        ValueData::new(Type::mk_ptr(), ValueKind::Function)
+        ValueData::new(Type::ptr(), ValueKind::Function)
     }
 
     pub fn ty(&self) -> &Type {

--- a/src/ir/exec/debugger.rs
+++ b/src/ir/exec/debugger.rs
@@ -22,7 +22,6 @@ use std::collections::HashSet;
 use std::io::{stdin, stdout, BufWriter, Write};
 
 use crate::ir::entities::FunctionKind;
-use crate::ir::passes::printer::Printer;
 use crate::ir::values::{Inst, ValueIndexer};
 use crate::ir::{
     module::Module,
@@ -231,12 +230,13 @@ impl<'a> Debugger<'a> {
 
             if let Some(inst) = inst {
                 println!("          ...");
-                let mut buf = BufWriter::new(Vec::new());
-                let mut printer = Printer::new(&mut buf);
-                printer.print_local_value(inst.into(), dfg).unwrap();
-                buf.flush().unwrap();
-                let output = String::from_utf8(buf.into_inner().unwrap()).unwrap();
-                println!("[{:^4}]     {}", inst.index(), output);
+                println!(
+                    "[{:^4}]     {}",
+                    inst.index(),
+                    Into::<Value>::into(inst)
+                        .format_as_local_value(dfg)
+                        .unwrap()
+                );
                 println!("          ...");
             } else {
                 let mut buf = BufWriter::new(Vec::new());
@@ -265,16 +265,15 @@ impl<'a> Debugger<'a> {
                     }
 
                     for (inst, _node) in node.insts() {
-                        write!(buf, "[{:^4}]    ", inst.index()).unwrap();
-                        // inefficient implementation, should be optimized
-                        let mut inner_buf = BufWriter::new(Vec::new());
-                        let mut printer = Printer::new(&mut inner_buf);
-                        printer.print_local_value(inst.into(), dfg).unwrap();
-                        inner_buf.flush().unwrap();
-                        let output = String::from_utf8(inner_buf.into_inner().unwrap()).unwrap();
-
-                        write!(buf, "{}", output).unwrap();
-                        writeln!(buf).unwrap();
+                        writeln!(
+                            buf,
+                            "[{:^4}]     {}",
+                            inst.index(),
+                            Into::<Value>::into(inst)
+                                .format_as_local_value(dfg)
+                                .unwrap()
+                        )
+                        .unwrap();
                     }
                 }
                 buf.flush().unwrap();

--- a/src/ir/exec/vm.rs
+++ b/src/ir/exec/vm.rs
@@ -258,7 +258,7 @@ impl<'a> VirtualMachine<'a> {
                     let (_len, ty) = data
                         .ty()
                         .as_array()
-                        .ok_or_else(|| ExecErr::InvalidType(data.ty().clone()))?;
+                        .ok_or_else(|| ExecErr::InvalidType(data.ty()))?;
                     let elem_size = ty.bytewidth();
 
                     let mut offset = 0;
@@ -273,7 +273,7 @@ impl<'a> VirtualMachine<'a> {
                     let field_types = data
                         .ty()
                         .as_struct()
-                        .ok_or_else(|| ExecErr::InvalidType(data.ty().clone()))?;
+                        .ok_or_else(|| ExecErr::InvalidType(data.ty()))?;
                     let mut offset = 0;
                     for (field, ty) in fields.iter().zip(field_types) {
                         let field_addr = Addr(addr.0 + offset);
@@ -421,8 +421,8 @@ impl<'a> VirtualMachine<'a> {
                 let op = binary.op();
                 let lhs = binary.lhs();
                 let rhs = binary.rhs();
-                let lhs_ty = dfg.with_value_data(lhs, |data| data.ty().clone()).unwrap();
-                let rhs_ty = dfg.with_value_data(rhs, |data| data.ty().clone()).unwrap();
+                let lhs_ty = dfg.with_value_data(lhs, |data| data.ty()).unwrap();
+                let rhs_ty = dfg.with_value_data(rhs, |data| data.ty()).unwrap();
                 let lhs_vreg = self.read_vreg(lhs);
                 let rhs_vreg = self.read_vreg(rhs);
 
@@ -549,7 +549,7 @@ impl<'a> VirtualMachine<'a> {
                     }
                     BinaryOp::ICmp(cond) => match cond {
                         ICmpCond::Eq => {
-                            let result_val = (lhs_val == rhs_val ).into();
+                            let result_val = (lhs_val == rhs_val).into();
                             self.write_vreg(self.curr_inst.into(), VReg(result_val));
                         }
                         ICmpCond::Ne => {
@@ -594,7 +594,7 @@ impl<'a> VirtualMachine<'a> {
                                 self.write_vreg(self.curr_inst.into(), VReg(result_val));
                             }
                             FCmpCond::OLt => {
-                                let result_val = (lhs_val < rhs_val ).into();
+                                let result_val = (lhs_val < rhs_val).into();
                                 self.write_vreg(self.curr_inst.into(), VReg(result_val));
                             }
                             FCmpCond::OLe => {
@@ -788,7 +788,7 @@ impl<'a> VirtualMachine<'a> {
 
                 let ty = value_data.ty();
                 let operand_ty = dfg
-                    .with_value_data(operand, |data| data.ty().clone())
+                    .with_value_data(operand, |data| data.ty())
                     .ok_or(ExecErr::ValueNotFound(operand))?;
 
                 let dest_size = ty.bytewidth();
@@ -1042,7 +1042,7 @@ impl<'a> VirtualMachine<'a> {
         }
 
         if !self.stopped() {
-            self.curr_inst = next_inst.ok_or_else(||ExecErr::EarlyStop(self.curr_inst.into()))?;
+            self.curr_inst = next_inst.ok_or_else(|| ExecErr::EarlyStop(self.curr_inst.into()))?;
             self.curr_function = next_function;
         }
 

--- a/src/ir/format.rs
+++ b/src/ir/format.rs
@@ -1,0 +1,306 @@
+use std::{
+    fmt,
+    io::{self, BufWriter, Write},
+};
+
+use super::{
+    entities::ValueKind,
+    module::{DataFlowGraph, Module},
+    values::{BinaryOp, CastOp, FCmpCond, ICmpCond, UnaryOp, Value},
+};
+
+impl fmt::Display for ICmpCond {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ICmpCond::Eq => write!(f, "eq"),
+            ICmpCond::Ne => write!(f, "ne"),
+            ICmpCond::Slt => write!(f, "slt"),
+            ICmpCond::Sle => write!(f, "sle"),
+        }
+    }
+}
+
+impl fmt::Display for FCmpCond {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FCmpCond::OEq => write!(f, "oeq"),
+            FCmpCond::ONe => write!(f, "one"),
+            FCmpCond::OLt => write!(f, "olt"),
+            FCmpCond::OLe => write!(f, "ole"),
+        }
+    }
+}
+
+impl fmt::Display for CastOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CastOp::Trunc => write!(f, "trunc"),
+            CastOp::ZExt => write!(f, "zext"),
+            CastOp::SExt => write!(f, "sext"),
+            CastOp::FpToUI => write!(f, "fptoui"),
+            CastOp::FpToSI => write!(f, "fptosi"),
+            CastOp::UIToFp => write!(f, "uitofp"),
+            CastOp::SIToFp => write!(f, "sitofp"),
+            CastOp::FpTrunc => write!(f, "fptrunc"),
+            CastOp::FpExt => write!(f, "fpext"),
+            CastOp::Bitcast => write!(f, "bitcast"),
+        }
+    }
+}
+
+impl fmt::Display for BinaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BinaryOp::Add => write!(f, "add"),
+            BinaryOp::FAdd => write!(f, "fadd"),
+            BinaryOp::Sub => write!(f, "sub"),
+            BinaryOp::FSub => write!(f, "fsub"),
+            BinaryOp::Mul => write!(f, "mul"),
+            BinaryOp::FMul => write!(f, "fmul"),
+            BinaryOp::UDiv => write!(f, "udiv"),
+            BinaryOp::SDiv => write!(f, "sdiv"),
+            BinaryOp::FDiv => write!(f, "fdiv"),
+            BinaryOp::URem => write!(f, "urem"),
+            BinaryOp::SRem => write!(f, "srem"),
+            BinaryOp::FRem => write!(f, "frem"),
+            BinaryOp::And => write!(f, "and"),
+            BinaryOp::Or => write!(f, "or"),
+            BinaryOp::Xor => write!(f, "xor"),
+            BinaryOp::Shl => write!(f, "shl"),
+            BinaryOp::LShr => write!(f, "lshr"),
+            BinaryOp::AShr => write!(f, "ashr"),
+            BinaryOp::ICmp(cond) => write!(f, "icmp.{}", cond),
+            BinaryOp::FCmp(cond) => write!(f, "fcmp.{}", cond),
+        }
+    }
+}
+
+impl fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UnaryOp::FNeg => write!(f, "fneg"),
+            UnaryOp::Not => write!(f, "not"),
+        }
+    }
+}
+
+impl Value {
+    /// Format the value as a global value.
+    pub fn format_as_global_value(&self, module: &Module) -> io::Result<String> {
+        let mut buf = BufWriter::new(Vec::new());
+        module
+            .with_value_data(*self, |data| {
+                match data.kind() {
+                    ValueKind::Zero => {
+                        write!(buf, "zero")
+                    }
+                    ValueKind::Undef => {
+                        write!(buf, "undef")
+                    }
+                    ValueKind::Bytes(bytes) => {
+                        // hexidecimal format with little endian
+                        write!(buf, "0x")?;
+                        for byte in bytes.iter().rev() {
+                            write!(buf, "{:02x}", byte)?;
+                        }
+                        Ok(())
+                    }
+                    ValueKind::Array(elems) => {
+                        write!(buf, "[")?;
+                        for (i, elem) in elems.iter().enumerate() {
+                            if i != 0 {
+                                write!(buf, ", ")?;
+                            }
+                            write!(buf, "{}", elem.format_as_global_value(module)?)?;
+                        }
+                        write!(buf, "]")
+                    }
+                    ValueKind::Struct(fields) => {
+                        write!(buf, "{{")?;
+                        for (i, field) in fields.iter().enumerate() {
+                            if i != 0 {
+                                write!(buf, ", ")?;
+                            }
+                            write!(buf, "{}", field.format_as_global_value(module)?)?;
+                        }
+                        write!(buf, "}}")
+                    }
+                    ValueKind::GlobalSlot(slot) => {
+                        let ty = module
+                            .with_value_data(slot.init(), |data| data.ty())
+                            .unwrap();
+                        if slot.mutable() {
+                            write!(buf, "global {} = {} ", module.value_name(*self), ty)?;
+                        } else {
+                            write!(buf, "const {} = {} ", module.value_name(*self), ty)?;
+                        }
+                        write!(buf, "{}", slot.init().format_as_global_value(module)?)
+                    }
+                    _ => panic!("unexpected local value kind when printing global value"),
+                }
+            })
+            .unwrap()?;
+
+        let s = String::from_utf8(buf.into_inner().unwrap()).unwrap();
+        Ok(s)
+    }
+
+    /// Format the value as a local operand for instructions.
+    pub fn format_as_operand(&self, dfg: &DataFlowGraph) -> io::Result<String> {
+        dfg.with_value_data(*self, |data| {
+            if data.kind().is_const() {
+                // self.print_local_value(*self, dfg)
+                self.format_as_local_value(dfg)
+            } else {
+                Ok(format!("{} {}", data.ty(), dfg.value_name(*self)))
+            }
+        })
+        .unwrap()
+    }
+
+    /// Format the value as a local inst/constant.
+    pub fn format_as_local_value(&self, dfg: &DataFlowGraph) -> io::Result<String> {
+        let mut buf = BufWriter::new(Vec::new());
+        let data = dfg.local_value_data(*self).unwrap();
+
+        match data.kind() {
+            ValueKind::Zero => write!(buf, "{} zero", data.ty())?,
+            ValueKind::Undef => write!(buf, "{} undef", data.ty())?,
+            ValueKind::Bytes(bytes) => {
+                // hexidecimal format with little endian
+                write!(buf, "{} 0x", data.ty())?;
+                if bytes.is_empty() {
+                    write!(buf, "00")?;
+                }
+                for byte in bytes.iter().rev() {
+                    write!(buf, "{:02x}", byte)?;
+                }
+            }
+            ValueKind::Array(elems) => {
+                write!(buf, "{} [", data.ty())?;
+                for (i, elem) in elems.iter().enumerate() {
+                    if i != 0 {
+                        write!(buf, ", ")?;
+                    }
+                    write!(buf, "{}", elem.format_as_local_value(dfg)?)?;
+                }
+                write!(buf, "]")?;
+            }
+            ValueKind::Struct(fields) => {
+                write!(buf, "{} {{", data.ty())?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i != 0 {
+                        write!(buf, ", ")?;
+                    }
+                    write!(buf, "{}", field.format_as_local_value(dfg)?)?;
+                }
+                write!(buf, "}}")?;
+            }
+            ValueKind::Alloc(alloc) => {
+                write!(buf, "{} = alloc {}", dfg.value_name(*self), alloc.ty())?;
+            }
+            ValueKind::Load(load) => {
+                write!(buf, "{} = load {}, ", dfg.value_name(*self), data.ty())?;
+                write!(buf, "{}", load.ptr().format_as_operand(dfg)?)?;
+            }
+            ValueKind::Cast(cast) => {
+                write!(
+                    buf,
+                    "{} = {} {}, ",
+                    dfg.value_name(*self),
+                    cast.op(),
+                    data.ty()
+                )?;
+                // self.print_operand(cast.val(), dfg)
+                write!(buf, "{}", cast.val().format_as_operand(dfg)?)?;
+            }
+            ValueKind::Store(store) => {
+                write!(buf, "store ")?;
+                write!(buf, "{}", store.val().format_as_operand(dfg)?)?;
+                write!(buf, ", ")?;
+                write!(buf, "{}", store.ptr().format_as_operand(dfg)?)?;
+            }
+            ValueKind::Binary(binary) => {
+                write!(buf, "{} = {} ", dfg.value_name(*self), binary.op())?;
+                write!(buf, "{}", binary.lhs().format_as_operand(dfg)?)?;
+                write!(buf, ", ")?;
+                write!(buf, "{}", binary.rhs().format_as_operand(dfg)?)?;
+            }
+            ValueKind::Unary(unary) => {
+                write!(buf, "{} = {} ", dfg.value_name(*self), unary.op())?;
+                write!(buf, "{}", unary.val().format_as_operand(dfg)?)?;
+            }
+            ValueKind::Jump(jump) => {
+                write!(buf, "jump {}(", dfg.block_name(jump.dst()))?;
+                for (i, arg) in jump.args().iter().enumerate() {
+                    if i != 0 {
+                        write!(buf, ", ")?;
+                    }
+                    write!(buf, "{}", arg.format_as_operand(dfg)?)?;
+                }
+                write!(buf, ")")?;
+            }
+            ValueKind::Branch(branch) => {
+                write!(buf, "br ")?;
+                write!(buf, "{}", branch.cond().format_as_operand(dfg)?)?;
+                write!(buf, ", {}", dfg.block_name(branch.then_dst()))?;
+                if !branch.then_args().is_empty() {
+                    write!(buf, "(")?;
+                    for (i, arg) in branch.then_args().iter().enumerate() {
+                        if i != 0 {
+                            write!(buf, ", ")?;
+                        }
+                        write!(buf, "{}", arg.format_as_operand(dfg)?)?;
+                    }
+                    write!(buf, ")")?;
+                }
+                write!(buf, ", {}", dfg.block_name(branch.else_dst()))?;
+                if !branch.else_args().is_empty() {
+                    write!(buf, "(")?;
+                    for (i, arg) in branch.else_args().iter().enumerate() {
+                        if i != 0 {
+                            write!(buf, ", ")?;
+                        }
+                        write!(buf, "{}", arg.format_as_operand(dfg)?)?;
+                    }
+                    write!(buf, ")")?;
+                }
+            }
+            ValueKind::Return(ret) => {
+                write!(buf, "ret ")?;
+                if let Some(val) = ret.val() {
+                    write!(buf, "{}", val.format_as_operand(dfg)?)?;
+                }
+            }
+            ValueKind::Call(call) => {
+                if !data.ty().is_void() {
+                    write!(buf, "{} = ", dfg.value_name(*self))?;
+                }
+                write!(buf, "call {} {}(", data.ty(), dfg.value_name(call.callee()))?;
+                for (i, arg) in call.args().iter().enumerate() {
+                    if i != 0 {
+                        write!(buf, ", ")?;
+                    }
+                    write!(buf, "{}", arg.format_as_operand(dfg)?)?;
+                }
+                write!(buf, ")")?;
+            }
+            ValueKind::GetElemPtr(gep) => {
+                write!(buf, "{} = getelemptr {}, ", dfg.value_name(*self), gep.ty())?;
+                write!(buf, "{}", gep.ptr().format_as_operand(dfg)?)?;
+                for idx in gep.indices() {
+                    write!(buf, ", ")?;
+                    write!(buf, "{}", idx.format_as_operand(dfg)?)?;
+                }
+            }
+            ValueKind::Function | ValueKind::GlobalSlot(_) | ValueKind::BlockParam => {
+                panic!(
+                    "function, global slot, and block param should not be formatted as local value."
+                );
+            }
+        }
+
+        let s = String::from_utf8(buf.into_inner().unwrap()).unwrap();
+        Ok(s)
+    }
+}

--- a/src/ir/frontend/convert.rs
+++ b/src/ir/frontend/convert.rs
@@ -379,6 +379,7 @@ impl Ast {
         }
     }
 
+    #[allow(clippy::only_used_in_recursion)]
     fn global_init_to_value(
         &self,
         ty: Type,

--- a/src/ir/frontend/convert.rs
+++ b/src/ir/frontend/convert.rs
@@ -2,7 +2,8 @@ use thiserror::Error;
 
 use crate::ir::{
     builders::{
-        BuilderErr, ConstantBuilder, GlobalValueBuilder, LocalBlockBuilder, LocalValueBuilder,
+        BuildAggregateConstant, BuildBlock, BuildError, BuildGlobalValue, BuildLocalValue,
+        BuildNonAggregateConstant,
     },
     module::Module,
     types::Type,
@@ -17,8 +18,8 @@ use super::{
 
 #[derive(Debug, Error)]
 pub enum SemanticError {
-    #[error("builder error: {0}")]
-    BuilderErr(BuilderErr),
+    #[error(transparent)]
+    BuildError(#[from] BuildError),
 
     #[error("name duplicated at {0:?}")]
     NameDuplicated(Span),
@@ -28,12 +29,6 @@ pub enum SemanticError {
 
     #[error("block name not found at {0:?}")]
     BlockNameNotFound(Span),
-}
-
-impl From<BuilderErr> for SemanticError {
-    fn from(err: BuilderErr) -> Self {
-        Self::BuilderErr(err)
-    }
 }
 
 struct AstLoweringContext {
@@ -390,7 +385,7 @@ impl Ast {
             AstNodeKind::Array(ref array) => {
                 let (_size, elem_type) = ty
                     .as_array()
-                    .ok_or_else(|| BuilderErr::InvalidType(ty.clone()))?;
+                    .ok_or_else(|| BuildError::InvalidType(ty.clone()))?;
                 let mut values = Vec::new();
                 for elem in array.elems.iter() {
                     let value = self.global_init_to_value(elem_type.clone(), elem, module)?;
@@ -402,7 +397,7 @@ impl Ast {
             AstNodeKind::Struct(ref struct_) => {
                 let struct_ty = ty
                     .as_struct()
-                    .ok_or_else(|| BuilderErr::InvalidType(ty.clone()))?;
+                    .ok_or_else(|| BuildError::InvalidType(ty.clone()))?;
                 let mut values = Vec::new();
                 for (i, field) in struct_.fields.iter().enumerate() {
                     let value = self.global_init_to_value(struct_ty[i].clone(), field, module)?;

--- a/src/ir/frontend/lexer.rs
+++ b/src/ir/frontend/lexer.rs
@@ -171,14 +171,10 @@ where
         }
 
         // convert the string to number
-        let number = match radix {
-            10 => u64::from_str_radix(&string, 10),
-            16 => u64::from_str_radix(&string, 16),
-            _ => unreachable!(),
-        };
+        let number = u64::from_str_radix(&string, radix);
 
-        if number.is_ok() {
-            let bytes = number.unwrap().to_le_bytes().to_vec();
+        if let Ok(number) = number {
+            let bytes = number.to_le_bytes().to_vec();
             // remove leading zeros
             let bytes = bytes
                 .into_iter()

--- a/src/ir/frontend/parser.rs
+++ b/src/ir/frontend/parser.rs
@@ -268,12 +268,12 @@ where
         let token = self.next_token()?;
         match token.kind {
             TokenKind::Keyword(ref kw) => match kw {
-                KeywordKind::Int(n) => Ok(Type::mk_int(*n)),
-                KeywordKind::Half => Ok(Type::mk_half()),
-                KeywordKind::Float => Ok(Type::mk_float()),
-                KeywordKind::Double => Ok(Type::mk_double()),
-                KeywordKind::Ptr => Ok(Type::mk_ptr()),
-                KeywordKind::Void => Ok(Type::mk_void()),
+                KeywordKind::Int(n) => Ok(Type::int(*n)),
+                KeywordKind::Half => Ok(Type::half()),
+                KeywordKind::Float => Ok(Type::float()),
+                KeywordKind::Double => Ok(Type::double()),
+                KeywordKind::Ptr => Ok(Type::ptr()),
+                KeywordKind::Void => Ok(Type::void()),
                 _ => Err(self.unexpected_token()),
             },
             _ => Err(self.unexpected_token()),
@@ -283,7 +283,7 @@ where
     fn parse_type_ident(&mut self) -> Result<Type, ParseError> {
         // consume the token
         match self.next_token()?.kind {
-            TokenKind::TypeIdent(ref name) => Ok(Type::mk_identified(name.clone())),
+            TokenKind::TypeIdent(ref name) => Ok(Type::identified(name.clone())),
             _ => Err(self.unexpected_token()),
         }
     }
@@ -302,7 +302,7 @@ where
                 },
             }
         }
-        Ok(Type::mk_struct(fields))
+        Ok(Type::struct_(fields))
     }
 
     fn parse_array_type(&mut self) -> Result<Type, ParseError> {
@@ -321,7 +321,7 @@ where
             return Err(self.unexpected_token());
         };
         self.expect(TokenKind::RightBracket)?;
-        Ok(Type::mk_array(size, ty))
+        Ok(Type::array(size, ty))
     }
 
     fn parse_function_type(&mut self) -> Result<Type, ParseError> {
@@ -340,7 +340,7 @@ where
         }
         self.expect(TokenKind::Arrow)?;
         let ret = self.parse_type()?;
-        Ok(Type::mk_function(params, ret))
+        Ok(Type::function(params, ret))
     }
 
     fn parse_block(&mut self) -> Result<AstNodeBox, ParseError> {

--- a/src/ir/frontend/tokens.rs
+++ b/src/ir/frontend/tokens.rs
@@ -4,9 +4,9 @@ use super::{InstKind, KeywordKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Pos {
-    row: usize,
-    col: usize,
-    idx: usize,
+    pub row: usize,
+    pub col: usize,
+    pub loc: usize,
 }
 
 impl Default for Pos {
@@ -14,7 +14,7 @@ impl Default for Pos {
         Self {
             row: 1,
             col: 0,
-            idx: 0,
+            loc: 0,
         }
     }
 }
@@ -31,7 +31,7 @@ impl Pos {
         } else {
             self.col += 1;
         }
-        self.idx += 1;
+        self.loc += 1;
     }
 }
 
@@ -43,8 +43,8 @@ impl fmt::Display for Pos {
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Span {
-    start: Pos,
-    end: Pos,
+    pub start: Pos,
+    pub end: Pos,
 }
 
 impl Default for Span {

--- a/src/ir/layout.rs
+++ b/src/ir/layout.rs
@@ -182,7 +182,7 @@ impl Layout {
     pub fn next_inst(&self, inst: Inst) -> Option<Inst> {
         let parent_block = self.parent_block(inst)?;
         let node = self.blocks.node(parent_block).unwrap();
-        
+
         node.insts().node(inst)?.next().or_else(|| {
             // this is the end of the block
             self.next_non_empty_block(parent_block)

--- a/src/ir/passes/control_flow_normalization.rs
+++ b/src/ir/passes/control_flow_normalization.rs
@@ -11,7 +11,7 @@
 use thiserror::Error;
 
 use crate::ir::{
-    builders::LocalValueBuilder,
+    builders::BuildLocalValue,
     entities::FunctionData,
     passes::LocalPassMut,
     values::{Block, Function},

--- a/src/ir/passes/dominance_analysis.rs
+++ b/src/ir/passes/dominance_analysis.rs
@@ -82,7 +82,7 @@ impl DominanceAnalysis {
 
     fn dfs(&mut self, block: Block, cfg: &ControlFlowGraph) {
         self.visited.insert(block);
-        for succ in cfg.succ(&block).unwrap() {
+        for succ in cfg.succs(&block).unwrap() {
             if !self.visited.contains(succ) {
                 self.dfs(*succ, cfg);
             }
@@ -138,7 +138,7 @@ impl LocalPass for DominanceAnalysis {
             for block in self.rpo.iter() {
                 // first processed predecessor of the block
                 let mut new_idom = None;
-                for pred in cfg.pred(block).unwrap() {
+                for pred in cfg.preds(block).unwrap() {
                     if pred == block {
                         continue;
                     }
@@ -150,7 +150,7 @@ impl LocalPass for DominanceAnalysis {
                 if new_idom.is_none() {
                     continue;
                 }
-                for pred in cfg.pred(block).unwrap() {
+                for pred in cfg.preds(block).unwrap() {
                     if idoms.get(pred).unwrap().is_some() {
                         new_idom = Some(self.intersect(new_idom.unwrap(), *pred, &idoms));
                     }
@@ -184,8 +184,8 @@ impl LocalPass for DominanceAnalysis {
         }
 
         for block in self.rpo.iter() {
-            if cfg.pred(block).unwrap().len() >= 2 {
-                for pred in cfg.pred(block).unwrap() {
+            if cfg.preds(block).unwrap().len() >= 2 {
+                for pred in cfg.preds(block).unwrap() {
                     let mut runner = *pred;
                     while runner != idoms[block].unwrap() {
                         frontiers.get_mut(&runner).unwrap().push(*block);

--- a/src/ir/passes/mem2reg.rs
+++ b/src/ir/passes/mem2reg.rs
@@ -147,7 +147,6 @@ impl Mem2reg {
                     }
                 }
             }
-            dbg!(dfg.value_name(value));
             Some(alloc.ty())
         } else {
             None
@@ -197,7 +196,7 @@ impl Mem2reg {
         }
 
         // edit the branch instructions
-        let succs = self.cfg.succ(&block).unwrap();
+        let succs = self.cfg.succs(&block).unwrap();
         for succ in succs {
             // args to extend the branch/jump instructions
             let mut args = Vec::new();
@@ -264,7 +263,6 @@ impl LocalPassMut for Mem2reg {
         // initialize the promotable variables
         for value in dfg.values().keys() {
             if let Some(ty) = self.promotable(*value, dfg) {
-                dbg!(dfg.value_name(*value));
                 self.variables.insert(*value);
                 self.def_blocks.insert(*value, HashSet::new());
                 self.worklists.insert(*value, VecDeque::new());

--- a/src/ir/passes/mem2reg.rs
+++ b/src/ir/passes/mem2reg.rs
@@ -29,7 +29,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use thiserror::Error;
 
 use crate::ir::{
-    builders::{ConstantBuilder, LocalValueBuilder},
+    builders::{BuildLocalValue, BuildNonAggregateConstant},
     entities::{FunctionData, ValueKind},
     module::DataFlowGraph,
     passes::{LocalPass, LocalPassMut},

--- a/src/ir/passes/mem2reg.rs
+++ b/src/ir/passes/mem2reg.rs
@@ -137,9 +137,18 @@ impl Mem2reg {
                             // the alloc result is used as a non-ptr value
                             return None;
                         }
+                        let ty = dfg.with_value_data(val, |data| data.ty()).unwrap();
+                        if ty != alloc.ty() {
+                            // different types in load and alloc
+                            return None;
+                        }
                     }
                     ValueKind::Load(_) => {
                         // the alloc result is used as a ptr in a load
+                        if data.ty() != alloc.ty() {
+                            // different types in load and alloc
+                            return None;
+                        }
                     }
                     _ => {
                         // the alloc result is used for other purposes

--- a/src/ir/passes/printer.rs
+++ b/src/ir/passes/printer.rs
@@ -25,7 +25,6 @@ where
 
     fn print_module(&mut self, module: &Module) -> io::Result<()> {
         writeln!(self.buf, "# orzir module: {} ", module.name())?;
-        writeln!(self.buf)?;
         for name in module.identified_type_layout() {
             let ty = Type::get_identified(name).unwrap();
             writeln!(self.buf, "type {} = {}", name, ty)?;

--- a/src/ir/passes/printer.rs
+++ b/src/ir/passes/printer.rs
@@ -149,7 +149,7 @@ where
                     }
                     ValueKind::GlobalSlot(slot) => {
                         let ty = module
-                            .with_value_data(slot.init(), |data| data.ty().clone())
+                            .with_value_data(slot.init(), |data| data.ty())
                             .unwrap();
                         if slot.mutable() {
                             write!(self.buf, "global {} = {} ", module.value_name(value), ty)?;

--- a/src/ir/passes/printer.rs
+++ b/src/ir/passes/printer.rs
@@ -1,5 +1,5 @@
 use crate::ir::{
-    entities::{FunctionKind, ValueKind},
+    entities::FunctionKind,
     module::{DataFlowGraph, Module},
     passes::GlobalPass,
     types::Type,
@@ -23,7 +23,7 @@ where
         Self { buf }
     }
 
-    pub fn print_module(&mut self, module: &Module) -> io::Result<()> {
+    fn print_module(&mut self, module: &Module) -> io::Result<()> {
         writeln!(self.buf, "# orzir module: {} ", module.name())?;
         writeln!(self.buf)?;
         for name in module.identified_type_layout() {
@@ -48,7 +48,7 @@ where
         Ok(())
     }
 
-    pub fn print_function(&mut self, function: Function, module: &Module) -> io::Result<()> {
+    fn print_function(&mut self, function: Function, module: &Module) -> io::Result<()> {
         let data = module.function_data(function).unwrap();
         let function_name = module.value_name(function.into());
 
@@ -101,221 +101,12 @@ where
         writeln!(self.buf, "}}")
     }
 
-    /// Print the value as operand in the instruction
-    pub fn print_operand(&mut self, value: Value, dfg: &DataFlowGraph) -> io::Result<()> {
-        dfg.with_value_data(value, |data| {
-            if data.kind().is_const() {
-                self.print_local_value(value, dfg)
-            } else {
-                write!(self.buf, "{} {}", data.ty(), dfg.value_name(value))
-            }
-        })
-        .unwrap()
+    fn print_global_value(&mut self, value: Value, module: &Module) -> io::Result<()> {
+        write!(self.buf, "{}", value.format_as_global_value(module)?)
     }
 
-    pub fn print_global_value(&mut self, value: Value, module: &Module) -> io::Result<()> {
-        module
-            .with_value_data(value, |data| {
-                match data.kind() {
-                    ValueKind::Zero => write!(self.buf, "zero"),
-                    ValueKind::Undef => write!(self.buf, "undef"),
-                    ValueKind::Bytes(bytes) => {
-                        // hexidecimal format with little endian
-                        write!(self.buf, "0x")?;
-                        for byte in bytes.iter().rev() {
-                            write!(self.buf, "{:02x}", byte)?;
-                        }
-                        Ok(())
-                    }
-                    ValueKind::Array(elems) => {
-                        write!(self.buf, "[")?;
-                        for (i, elem) in elems.iter().enumerate() {
-                            if i != 0 {
-                                write!(self.buf, ", ")?;
-                            }
-                            self.print_global_value(*elem, module)?;
-                        }
-                        write!(self.buf, "]")
-                    }
-                    ValueKind::Struct(fields) => {
-                        write!(self.buf, "{{")?;
-                        for (i, field) in fields.iter().enumerate() {
-                            if i != 0 {
-                                write!(self.buf, ", ")?;
-                            }
-                            self.print_global_value(*field, module)?;
-                        }
-                        write!(self.buf, "}}")
-                    }
-                    ValueKind::GlobalSlot(slot) => {
-                        let ty = module
-                            .with_value_data(slot.init(), |data| data.ty())
-                            .unwrap();
-                        if slot.mutable() {
-                            write!(self.buf, "global {} = {} ", module.value_name(value), ty)?;
-                        } else {
-                            write!(self.buf, "const {} = {} ", module.value_name(value), ty)?;
-                        }
-                        self.print_global_value(slot.init(), module)
-                    }
-                    _ => panic!("unexpected local value kind when printing global value"),
-                }
-            })
-            .unwrap()
-    }
-
-    pub fn print_local_value(&mut self, value: Value, dfg: &DataFlowGraph) -> io::Result<()> {
-        let data = dfg.local_value_data(value).unwrap();
-
-        match data.kind() {
-            ValueKind::Zero => write!(self.buf, "{} zero", data.ty()),
-            ValueKind::Undef => write!(self.buf, "{} undef", data.ty()),
-            ValueKind::Bytes(bytes) => {
-                // hexidecimal format with little endian
-                write!(self.buf, "{} 0x", data.ty())?;
-                if bytes.is_empty() {
-                    write!(self.buf, "00")?;
-                }
-                for byte in bytes.iter().rev() {
-                    write!(self.buf, "{:02x}", byte)?;
-                }
-                Ok(())
-            }
-            ValueKind::Array(elems) => {
-                write!(self.buf, "{} [", data.ty())?;
-                for (i, elem) in elems.iter().enumerate() {
-                    if i != 0 {
-                        write!(self.buf, ", ")?;
-                    }
-                    self.print_local_value(*elem, dfg)?;
-                }
-                write!(self.buf, "]")
-            }
-            ValueKind::Struct(fields) => {
-                write!(self.buf, "{} {{", data.ty())?;
-                for (i, field) in fields.iter().enumerate() {
-                    if i != 0 {
-                        write!(self.buf, ", ")?;
-                    }
-                    self.print_local_value(*field, dfg)?;
-                }
-                write!(self.buf, "}}")
-            }
-            ValueKind::Alloc(alloc) => {
-                write!(self.buf, "{} = alloc {}", dfg.value_name(value), alloc.ty())
-            }
-            ValueKind::Load(load) => {
-                write!(self.buf, "{} = load {}, ", dfg.value_name(value), data.ty())?;
-                self.print_operand(load.ptr(), dfg)
-            }
-            ValueKind::Cast(cast) => {
-                write!(
-                    self.buf,
-                    "{} = {} {}, ",
-                    dfg.value_name(value),
-                    cast.op(),
-                    data.ty()
-                )?;
-                self.print_operand(cast.val(), dfg)
-            }
-            ValueKind::Store(store) => {
-                write!(self.buf, "store ")?;
-                self.print_operand(store.val(), dfg)?;
-                write!(self.buf, ", ")?;
-                self.print_operand(store.ptr(), dfg)
-            }
-            ValueKind::Binary(binary) => {
-                write!(self.buf, "{} = {} ", dfg.value_name(value), binary.op())?;
-                self.print_operand(binary.lhs(), dfg)?;
-                write!(self.buf, ", ")?;
-                self.print_operand(binary.rhs(), dfg)
-            }
-            ValueKind::Unary(unary) => {
-                write!(self.buf, "{} = {} ", dfg.value_name(value), unary.op())?;
-                self.print_operand(unary.val(), dfg)
-            }
-            ValueKind::Jump(jump) => {
-                write!(self.buf, "jump {}(", dfg.block_name(jump.dst()))?;
-                for (i, arg) in jump.args().iter().enumerate() {
-                    if i != 0 {
-                        write!(self.buf, ", ")?;
-                    }
-                    self.print_operand(*arg, dfg)?;
-                }
-                write!(self.buf, ")")
-            }
-            ValueKind::Branch(branch) => {
-                write!(self.buf, "br ")?;
-                self.print_operand(branch.cond(), dfg)?;
-                write!(self.buf, ", {}", dfg.block_name(branch.then_dst()))?;
-                if !branch.then_args().is_empty() {
-                    write!(self.buf, "(")?;
-                    for (i, arg) in branch.then_args().iter().enumerate() {
-                        if i != 0 {
-                            write!(self.buf, ", ")?;
-                        }
-                        self.print_operand(*arg, dfg)?;
-                    }
-                    write!(self.buf, ")")?;
-                }
-                write!(self.buf, ", {}", dfg.block_name(branch.else_dst()))?;
-                if !branch.else_args().is_empty() {
-                    write!(self.buf, "(")?;
-                    for (i, arg) in branch.else_args().iter().enumerate() {
-                        if i != 0 {
-                            write!(self.buf, ", ")?;
-                        }
-                        self.print_operand(*arg, dfg)?;
-                    }
-                    write!(self.buf, ")")?;
-                }
-                Ok(())
-            }
-            ValueKind::Return(ret) => {
-                write!(self.buf, "ret ")?;
-                if let Some(val) = ret.val() {
-                    self.print_operand(val, dfg)?;
-                }
-                Ok(())
-            }
-            ValueKind::Call(call) => {
-                if !data.ty().is_void() {
-                    write!(self.buf, "{} = ", dfg.value_name(value))?;
-                }
-                write!(
-                    self.buf,
-                    "call {} {}(",
-                    data.ty(),
-                    dfg.value_name(call.callee())
-                )?;
-                for (i, arg) in call.args().iter().enumerate() {
-                    if i != 0 {
-                        write!(self.buf, ", ")?;
-                    }
-                    self.print_operand(*arg, dfg)?;
-                }
-                write!(self.buf, ")")
-            }
-            ValueKind::GetElemPtr(gep) => {
-                write!(
-                    self.buf,
-                    "{} = getelemptr {}, ",
-                    dfg.value_name(value),
-                    gep.ty()
-                )?;
-                self.print_operand(gep.ptr(), dfg)?;
-                for idx in gep.indices() {
-                    write!(self.buf, ", ")?;
-                    self.print_operand(*idx, dfg)?;
-                }
-                Ok(())
-            }
-            ValueKind::Function | ValueKind::GlobalSlot(_) | ValueKind::BlockParam => {
-                panic!(
-                    "function, global slot, and block param should not be printed as local value"
-                );
-            }
-        }
+    fn print_local_value(&mut self, value: Value, dfg: &DataFlowGraph) -> io::Result<()> {
+        write!(self.buf, "{}", value.format_as_local_value(dfg)?)
     }
 }
 

--- a/src/ir/passes/unreachable_block_elimination.rs
+++ b/src/ir/passes/unreachable_block_elimination.rs
@@ -37,7 +37,7 @@ impl LocalPassMut for UnreachableBlockElimination {
         reachable_blocks.insert(entry_block);
 
         while let Some(block) = queue.pop_front() {
-            if let Some(succs) = cfg.succ(&block) {
+            if let Some(succs) = cfg.succs(&block) {
                 for &succ in succs.iter() {
                     if reachable_blocks.insert(succ) {
                         // the block is not visited yet

--- a/src/ir/values.rs
+++ b/src/ir/values.rs
@@ -11,7 +11,6 @@ use super::{
     entities::{ValueData, ValueKind},
     types::Type,
 };
-use std::fmt;
 
 /// Value reference
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -38,16 +37,19 @@ pub trait ValueIndexer: From<Value> {
 
 /// Reference to an instruction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct Inst(usize);
 
 /// Reference to a function.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct Function(usize);
 
 /// Reference to a block
 ///
 /// Blocks are independent from values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct Block(usize);
 
 /// Implement the value indexer trait for given indexer.
@@ -103,17 +105,6 @@ pub enum ICmpCond {
     Sle,
 }
 
-impl fmt::Display for ICmpCond {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ICmpCond::Eq => write!(f, "eq"),
-            ICmpCond::Ne => write!(f, "ne"),
-            ICmpCond::Slt => write!(f, "slt"),
-            ICmpCond::Sle => write!(f, "sle"),
-        }
-    }
-}
-
 /// Condition for floating-point comparison
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FCmpCond {
@@ -121,17 +112,6 @@ pub enum FCmpCond {
     ONe,
     OLt,
     OLe,
-}
-
-impl fmt::Display for FCmpCond {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FCmpCond::OEq => write!(f, "oeq"),
-            FCmpCond::ONe => write!(f, "one"),
-            FCmpCond::OLt => write!(f, "olt"),
-            FCmpCond::OLe => write!(f, "ole"),
-        }
-    }
 }
 
 /// Binary operations.
@@ -220,33 +200,6 @@ impl BinaryOp {
     }
 }
 
-impl fmt::Display for BinaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            BinaryOp::Add => write!(f, "add"),
-            BinaryOp::FAdd => write!(f, "fadd"),
-            BinaryOp::Sub => write!(f, "sub"),
-            BinaryOp::FSub => write!(f, "fsub"),
-            BinaryOp::Mul => write!(f, "mul"),
-            BinaryOp::FMul => write!(f, "fmul"),
-            BinaryOp::UDiv => write!(f, "udiv"),
-            BinaryOp::SDiv => write!(f, "sdiv"),
-            BinaryOp::FDiv => write!(f, "fdiv"),
-            BinaryOp::URem => write!(f, "urem"),
-            BinaryOp::SRem => write!(f, "srem"),
-            BinaryOp::FRem => write!(f, "frem"),
-            BinaryOp::And => write!(f, "and"),
-            BinaryOp::Or => write!(f, "or"),
-            BinaryOp::Xor => write!(f, "xor"),
-            BinaryOp::Shl => write!(f, "shl"),
-            BinaryOp::LShr => write!(f, "lshr"),
-            BinaryOp::AShr => write!(f, "ashr"),
-            BinaryOp::ICmp(cond) => write!(f, "icmp.{}", cond),
-            BinaryOp::FCmp(cond) => write!(f, "fcmp.{}", cond),
-        }
-    }
-}
-
 /// Unary operations.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UnaryOp {
@@ -265,15 +218,6 @@ impl UnaryOp {
     /// If the operation requires floating-point operands
     pub(super) fn require_float(&self) -> bool {
         matches!(self, UnaryOp::FNeg)
-    }
-}
-
-impl fmt::Display for UnaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UnaryOp::FNeg => write!(f, "fneg"),
-            UnaryOp::Not => write!(f, "not"),
-        }
     }
 }
 
@@ -456,23 +400,6 @@ pub enum CastOp {
 
     /// Bitcast
     Bitcast,
-}
-
-impl fmt::Display for CastOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CastOp::Trunc => write!(f, "trunc"),
-            CastOp::ZExt => write!(f, "zext"),
-            CastOp::SExt => write!(f, "sext"),
-            CastOp::FpToUI => write!(f, "fptoui"),
-            CastOp::FpToSI => write!(f, "fptosi"),
-            CastOp::UIToFp => write!(f, "uitofp"),
-            CastOp::SIToFp => write!(f, "sitofp"),
-            CastOp::FpTrunc => write!(f, "fptrunc"),
-            CastOp::FpExt => write!(f, "fpext"),
-            CastOp::Bitcast => write!(f, "bitcast"),
-        }
-    }
 }
 
 /// Type cast

--- a/src/ir/values.rs
+++ b/src/ir/values.rs
@@ -312,7 +312,7 @@ pub struct Store {
 
 impl Store {
     pub(super) fn new_value_data(val: Value, ptr: Value) -> ValueData {
-        ValueData::new(Type::mk_void(), ValueKind::Store(Store { val, ptr }))
+        ValueData::new(Type::void(), ValueKind::Store(Store { val, ptr }))
     }
 
     pub fn val(&self) -> Value {
@@ -451,7 +451,7 @@ pub struct Alloc {
 
 impl Alloc {
     pub(super) fn new_value_data(ty: Type) -> ValueData {
-        ValueData::new(Type::mk_ptr(), ValueKind::Alloc(Alloc { ty }))
+        ValueData::new(Type::ptr(), ValueKind::Alloc(Alloc { ty }))
     }
 
     pub fn ty(&self) -> Type {
@@ -510,7 +510,7 @@ pub struct Jump {
 
 impl Jump {
     pub(super) fn new_value_data(dst: Block, args: Vec<Value>) -> ValueData {
-        ValueData::new(Type::mk_void(), ValueKind::Jump(Jump { dst, args }))
+        ValueData::new(Type::void(), ValueKind::Jump(Jump { dst, args }))
     }
 
     pub fn dst(&self) -> Block {
@@ -569,7 +569,7 @@ impl Branch {
         else_args: Vec<Value>,
     ) -> ValueData {
         ValueData::new(
-            Type::mk_void(),
+            Type::void(),
             ValueKind::Branch(Branch {
                 cond,
                 then_dst,
@@ -669,7 +669,7 @@ pub struct Return {
 
 impl Return {
     pub(super) fn new_value_data(val: Option<Value>) -> ValueData {
-        ValueData::new(Type::mk_void(), ValueKind::Return(Return { val }))
+        ValueData::new(Type::void(), ValueKind::Return(Return { val }))
     }
 
     pub fn val(&self) -> Option<Value> {
@@ -751,7 +751,7 @@ pub struct GetElemPtr {
 impl GetElemPtr {
     pub(super) fn new_value_data(ptr: Value, ty: Type, indices: Vec<Value>) -> ValueData {
         ValueData::new(
-            Type::mk_ptr(),
+            Type::ptr(),
             ValueKind::GetElemPtr(GetElemPtr { ptr, ty, indices }),
         )
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,6 @@ struct DbgCommand {
 }
 
 fn cli() -> Command {
-    
-
     Command::new("orzcc").subcommand(
         Command::new("dbg").about("Debug the given IR file").arg(
             Arg::new("file")

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,30 @@
 use clap::{Arg, Command};
-use orzcc::ir::{exec::debugger::Debugger, frontend::parser::Parser};
+use orzcc::{
+    collections::diagnostic::{Diagnostic, Level},
+    ir::{
+        exec::debugger::Debugger,
+        frontend::{
+            convert::SemanticError,
+            parser::{ParseError, Parser},
+        },
+        module::Module,
+    },
+};
 
 /// The debugger command
 struct DbgCommand {
     file: String,
+}
+
+fn main() {
+    let cmd = parse_args();
+    let module = parse_orzir(&cmd.file);
+    if module.is_none() {
+        return;
+    }
+    let module = module.unwrap();
+    let mut debugger = Debugger::new(&module);
+    debugger.repl();
 }
 
 fn cli() -> Command {
@@ -29,15 +50,92 @@ fn parse_args() -> DbgCommand {
     }
 }
 
-fn main() {
-    let cmd = parse_args();
-    let mut file = std::fs::File::open(cmd.file).unwrap();
+fn parse_orzir(path: &str) -> Option<Module> {
+    let mut file = std::fs::File::open(path).unwrap();
     let mut parser = Parser::new(&mut file);
-    let module = parser
-        .parse()
-        .unwrap()
-        .into_ir("debugging-module".into())
-        .unwrap();
-    let mut debugger = Debugger::new(&module);
-    debugger.repl();
+    let result = parser.parse();
+
+    if let Err(e) = result {
+        // source code in the file
+        let s = std::fs::read_to_string(path).unwrap();
+        let diagnostic = match e {
+            ParseError::LexerError(pos) => Diagnostic::new(
+                &s,
+                Level::Error,
+                path.to_string(),
+                format!("{}", e),
+                (pos.row, pos.row),
+                pos.row,
+                (pos.col, pos.col),
+            ),
+            ParseError::UnexpectedToken(span) => {
+                let start = span.start;
+                let end = span.end;
+                Diagnostic::new(
+                    &s,
+                    Level::Error,
+                    path.to_string(),
+                    format!("{}", e),
+                    (start.row, end.row),
+                    start.row,
+                    (start.col, end.col),
+                )
+            }
+        };
+
+        println!("{}", diagnostic);
+        return None;
+    }
+
+    let result = result.unwrap().into_ir(path.to_string());
+    if let Err(ref e) = result {
+        let s = std::fs::read_to_string(path).unwrap();
+        match e {
+            SemanticError::BuildError(e) => println!("error: {}", e),
+            SemanticError::NameDuplicated(span) => {
+                let start = span.start;
+                let end = span.end;
+                let diagnostic = Diagnostic::new(
+                    &s,
+                    Level::Error,
+                    path.to_string(),
+                    format!("{}", e),
+                    (start.row, end.row),
+                    start.row,
+                    (start.col, end.col),
+                );
+                println!("{}", diagnostic);
+            }
+            SemanticError::ValueNameNotFound(span) => {
+                let start = span.start;
+                let end = span.end;
+                let diagnostic = Diagnostic::new(
+                    &s,
+                    Level::Error,
+                    path.to_string(),
+                    format!("{}", e),
+                    (start.row, end.row),
+                    start.row,
+                    (start.col, end.col),
+                );
+                println!("{}", diagnostic);
+            }
+            SemanticError::BlockNameNotFound(span) => {
+                let start = span.start;
+                let end = span.end;
+                let diagnostic = Diagnostic::new(
+                    &s,
+                    Level::Error,
+                    path.to_string(),
+                    format!("{}", e),
+                    (start.row, end.row),
+                    start.row,
+                    (start.col, end.col),
+                );
+                println!("{}", diagnostic);
+            }
+        }
+    }
+
+    result.ok()
 }


### PR DESCRIPTION
Some miscellaneous changes are made in this PR.
- A lot of break changes in the IR construction API.
- Add diagnostic for IR frontend, if there are errors with the IR source code, a diagnostic information will be printed. For example, a function definition without return type will lead to the diagnostic below:
```
error
  ---> tests/orzir_cases/00_arithmetic.orzir:45:21
   |
45 | func @add(i32, i32) {
   |                     ^ unexpected token at 45:21-45:21
   |
```

The diagnostic information might be useful for handwriting the IR programs.